### PR TITLE
패키지 외부에서 ToastType('success' | 'error' | 'info' | 'warning')을 사용할 수 있도록 함.

### DIFF
--- a/src/evoui/components/Toast/index.ts
+++ b/src/evoui/components/Toast/index.ts
@@ -1,1 +1,2 @@
 export { Toast, sendToast } from './toast';
+export { ToastType } from './toast.type';

--- a/src/evoui/components/Toast/toast.tsx
+++ b/src/evoui/components/Toast/toast.tsx
@@ -1,7 +1,16 @@
 import { useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import styled from 'styled-components';
-import { ToastType } from './toast.type';
+import {
+  CloseButtonPropsType,
+  ContentPropsType,
+  HeaderPropsType,
+  IconPropsType,
+  IndependentToastPropsType,
+  RootPropsType,
+  TitlePropsType,
+  ToastContentPropsType,
+} from './toast.type';
 
 const Canvas = styled.div`
   position: fixed;
@@ -29,7 +38,7 @@ const ToastWrapper = styled.div`
   }
 `;
 
-const Root = styled.div<ToastType.RootPropsType>`
+const Root = styled.div<RootPropsType>`
   width: 100%;
   display: flex;
   flex-direction: row-reverse;
@@ -39,7 +48,7 @@ const Root = styled.div<ToastType.RootPropsType>`
   ${(props) => props.cssStyle ?? ''};
 `;
 
-const ToastContent = styled.div<ToastType.ToastContentPropsType>`
+const ToastContent = styled.div<ToastContentPropsType>`
   width: fit-content;
   height: fit-content;
   border-radius: 8px;
@@ -96,7 +105,7 @@ const ToastContent = styled.div<ToastType.ToastContentPropsType>`
   ${(props) => props.cssStyle ?? ''};
 `;
 
-const Header = styled.div<ToastType.HeaderPropsType>`
+const Header = styled.div<HeaderPropsType>`
   display: flex;
   flex-direction: row;
   margin-bottom: 4px;
@@ -104,7 +113,7 @@ const Header = styled.div<ToastType.HeaderPropsType>`
   ${(props) => props.cssStyle ?? ''};
 `;
 
-const Icon = styled.div<ToastType.IconPropsType>`
+const Icon = styled.div<IconPropsType>`
   margin: 3px 6px auto 0;
   line-height: 0;
 
@@ -115,7 +124,7 @@ const Icon = styled.div<ToastType.IconPropsType>`
   ${(props) => props.cssStyle ?? ''};
 `;
 
-const Title = styled.div<ToastType.TitlePropsType>`
+const Title = styled.div<TitlePropsType>`
   margin: auto auto auto 0;
   padding-bottom: 2px;
   line-height: 21px;
@@ -125,7 +134,7 @@ const Title = styled.div<ToastType.TitlePropsType>`
   ${(props) => props.cssStyle ?? ''};
 `;
 
-const CloseButton = styled.div<ToastType.CloseButtonPropsType>`
+const CloseButton = styled.div<CloseButtonPropsType>`
   margin: -4px -6px auto 3px;
   width: 22px;
   height: 22px;
@@ -146,7 +155,7 @@ const CloseButton = styled.div<ToastType.CloseButtonPropsType>`
   ${(props) => props.cssStyle ?? ''};
 `;
 
-const Content = styled.div<ToastType.ContentPropsType>`
+const Content = styled.div<ContentPropsType>`
   line-height: 17px;
   font-size: 15px;
   padding-left: 25px;
@@ -163,7 +172,7 @@ function IndependentToast({
   icon,
   closeButton,
   overrides,
-}: ToastType.IndependentToastPropsType) {
+}: IndependentToastPropsType) {
   useEffect(() => {
     setTimeout(() => {
       if (!!ref.current) {
@@ -325,7 +334,7 @@ function IndependentToast({
 function ToastCanvas() {
   const [changed, setChanged] = useState(false);
   const [list, setList] = useState<
-    Array<{ toast: ToastType.IndependentToastPropsType; key: number }>
+    Array<{ toast: IndependentToastPropsType; key: number }>
   >([]);
 
   useEffect(() => {
@@ -380,11 +389,11 @@ class ToastManager {
   private static maxDisplaySize: number = 0;
 
   private static toastQueue: Array<{
-    toast: ToastType.IndependentToastPropsType;
+    toast: IndependentToastPropsType;
     key: number;
   }> = [];
   private static displayList: Array<{
-    toast: ToastType.IndependentToastPropsType;
+    toast: IndependentToastPropsType;
     key: number;
   }> = [];
   private static toastKey: number = 0;
@@ -405,7 +414,7 @@ class ToastManager {
     this.initialized = false;
   }
 
-  static enqueueToast(toastProps: ToastType.IndependentToastPropsType) {
+  static enqueueToast(toastProps: IndependentToastPropsType) {
     if (!this.isInitialized()) {
       this.uninitializedError();
     }
@@ -467,7 +476,7 @@ export function sendToast({
   icon,
   closeButton,
   overrides,
-}: ToastType.IndependentToastPropsType) {
+}: IndependentToastPropsType) {
   ToastManager.enqueueToast({
     title,
     content,

--- a/src/evoui/components/Toast/toast.type.ts
+++ b/src/evoui/components/Toast/toast.type.ts
@@ -1,60 +1,42 @@
 import { DefaultOverridesType, DefaultPropsType } from '../global.type';
 
 // internal types: 패키지 외부에서 사용 불가
-export namespace ToastType {
-  export interface IndependentToastPropsType {
-    /** Title of the toast. It must be a string.*/
-    title: string;
-    /** Content of the toast.*/
-    content?: string | React.ReactInstance | React.ReactElement;
-    /** Type of the toast. It must be one of 'success', 'error', 'info', 'warning'. Default value is 'info'. */
-    type?: ToastType;
-    /** The duration how long the toast will be displayed. */
-    duration?: number;
-    /** Is the toast could be closed. */
-    closable?: boolean;
-    /** If set, the default icon will be replaced. */
-    icon?: string | React.ReactInstance | React.ReactElement;
-    /** If set, the default close button icon be replaced. */
-    closeButton?: string | React.ReactInstance | React.ReactElement;
-    /** UI elements props will be overridden. Only css value is available on current version. */
-    overrides?: {
-      Root?: DefaultOverridesType;
-      ToastContent?: DefaultOverridesType;
-      Header?: DefaultOverridesType;
-      Icon?: DefaultOverridesType;
-      Title?: DefaultOverridesType;
-      CloseButton?: DefaultOverridesType;
-      Content?: DefaultOverridesType;
-    };
-  }
-
-  export interface RootPropsType extends DefaultPropsType {}
-
-  export interface ToastContentPropsType extends DefaultPropsType {
-    type: ToastType;
-    willRemoved?: boolean;
-  }
-
-  export interface HeaderPropsType extends DefaultPropsType {}
-
-  export interface IconPropsType extends DefaultPropsType {}
-
-  export interface TitlePropsType extends DefaultPropsType {}
-
-  export interface CloseButtonPropsType extends DefaultPropsType {}
-
-  export interface ContentPropsType extends DefaultPropsType {}
-
-  export interface PropsType {
-    /** UI elements props will be overridden. Only css value is available on current version. */
-    overrides?: {
-      Root?: DefaultOverridesType;
-    };
-    onOpen?: () => any;
-    onClose?: () => any;
-  }
+export interface IndependentToastPropsType {
+  /** Title of the toast. It must be a string.*/
+  title: string;
+  /** Content of the toast.*/
+  content?: string | React.ReactInstance | React.ReactElement;
+  /** Type of the toast. It must be one of 'success', 'error', 'info', 'warning'. Default value is 'info'. */
+  type?: ToastType;
+  /** The duration how long the toast will be displayed. */
+  duration?: number;
+  /** Is the toast could be closed. */
+  closable?: boolean;
+  /** If set, the default icon will be replaced. */
+  icon?: string | React.ReactInstance | React.ReactElement;
+  /** If set, the default close button icon be replaced. */
+  closeButton?: string | React.ReactInstance | React.ReactElement;
+  /** UI elements props will be overridden. Only css value is available on current version. */
+  overrides?: {
+    Root?: DefaultOverridesType;
+    ToastContent?: DefaultOverridesType;
+    Header?: DefaultOverridesType;
+    Icon?: DefaultOverridesType;
+    Title?: DefaultOverridesType;
+    CloseButton?: DefaultOverridesType;
+    Content?: DefaultOverridesType;
+  };
 }
+export interface RootPropsType extends DefaultPropsType {}
+export interface ToastContentPropsType extends DefaultPropsType {
+  type: ToastType;
+  willRemoved?: boolean;
+}
+export interface HeaderPropsType extends DefaultPropsType {}
+export interface IconPropsType extends DefaultPropsType {}
+export interface TitlePropsType extends DefaultPropsType {}
+export interface CloseButtonPropsType extends DefaultPropsType {}
+export interface ContentPropsType extends DefaultPropsType {}
 
 // external types: 패키지 외부에서 사용 가능
 export type ToastType = 'success' | 'error' | 'info' | 'warning';

--- a/src/evoui/components/Toast/toast.type.ts
+++ b/src/evoui/components/Toast/toast.type.ts
@@ -1,32 +1,35 @@
 import { DefaultOverridesType, DefaultPropsType } from '../global.type';
 
+type OptionalIndependentToastPropsType = Partial<{
+  /** Content of the toast.*/
+  content: string | React.ReactInstance | React.ReactElement;
+  /** Type of the toast. It must be one of 'success', 'error', 'info', 'warning'. Default value is 'info'. */
+  type: ToastType;
+  /** The duration how long the toast will be displayed. */
+  duration: number;
+  /** Is the toast could be closed. */
+  closable: boolean;
+  /** If set, the default icon will be replaced. */
+  icon: string | React.ReactInstance | React.ReactElement;
+  /** If set, the default close button icon be replaced. */
+  closeButton: string | React.ReactInstance | React.ReactElement;
+  /** UI elements props will be overridden. Only css value is available on current version. */
+  overrides: Partial<{
+    Root: DefaultOverridesType;
+    ToastContent: DefaultOverridesType;
+    Header: DefaultOverridesType;
+    Icon: DefaultOverridesType;
+    Title: DefaultOverridesType;
+    CloseButton: DefaultOverridesType;
+    Content: DefaultOverridesType;
+  }>;
+}>;
+
 // internal types: 패키지 외부에서 사용 불가
-export interface IndependentToastPropsType {
+export type IndependentToastPropsType = OptionalIndependentToastPropsType & {
   /** Title of the toast. It must be a string.*/
   title: string;
-  /** Content of the toast.*/
-  content?: string | React.ReactInstance | React.ReactElement;
-  /** Type of the toast. It must be one of 'success', 'error', 'info', 'warning'. Default value is 'info'. */
-  type?: ToastType;
-  /** The duration how long the toast will be displayed. */
-  duration?: number;
-  /** Is the toast could be closed. */
-  closable?: boolean;
-  /** If set, the default icon will be replaced. */
-  icon?: string | React.ReactInstance | React.ReactElement;
-  /** If set, the default close button icon be replaced. */
-  closeButton?: string | React.ReactInstance | React.ReactElement;
-  /** UI elements props will be overridden. Only css value is available on current version. */
-  overrides?: {
-    Root?: DefaultOverridesType;
-    ToastContent?: DefaultOverridesType;
-    Header?: DefaultOverridesType;
-    Icon?: DefaultOverridesType;
-    Title?: DefaultOverridesType;
-    CloseButton?: DefaultOverridesType;
-    Content?: DefaultOverridesType;
-  };
-}
+};
 export interface RootPropsType extends DefaultPropsType {}
 export interface ToastContentPropsType extends DefaultPropsType {
   type: ToastType;

--- a/src/evoui/components/Toast/toast.type.ts
+++ b/src/evoui/components/Toast/toast.type.ts
@@ -1,15 +1,14 @@
 import { DefaultOverridesType, DefaultPropsType } from '../global.type';
 
+// internal types: 패키지 외부에서 사용 불가
 export namespace ToastType {
-  type ToastTypes = 'success' | 'error' | 'info' | 'warning';
-
   export interface IndependentToastPropsType {
     /** Title of the toast. It must be a string.*/
     title: string;
     /** Content of the toast.*/
     content?: string | React.ReactInstance | React.ReactElement;
     /** Type of the toast. It must be one of 'success', 'error', 'info', 'warning'. Default value is 'info'. */
-    type?: ToastTypes;
+    type?: ToastType;
     /** The duration how long the toast will be displayed. */
     duration?: number;
     /** Is the toast could be closed. */
@@ -33,7 +32,7 @@ export namespace ToastType {
   export interface RootPropsType extends DefaultPropsType {}
 
   export interface ToastContentPropsType extends DefaultPropsType {
-    type: ToastTypes;
+    type: ToastType;
     willRemoved?: boolean;
   }
 
@@ -56,3 +55,6 @@ export namespace ToastType {
     onClose?: () => any;
   }
 }
+
+// external types: 패키지 외부에서 사용 가능
+export type ToastType = 'success' | 'error' | 'info' | 'warning';

--- a/src/evoui/components/index.ts
+++ b/src/evoui/components/index.ts
@@ -20,4 +20,4 @@ export {
   ModalBody as ModalBody,
   ModalFooter as ModalFooter,
 } from './Modal';
-export { Toast, sendToast } from './Toast';
+export { Toast, sendToast, ToastType } from './Toast';


### PR DESCRIPTION
## Checklist before merge ✅

- [x] PR 제목이 직관적인가요?
  - 짧고 간결하지만 명확하게 (브랜치 명 금지)
  - Jira Ticket 있을 경우 함께 남기기
- [x] 코드 리뷰가 완료되었나요?

## What is this PR? 🚀

> 아래 항목 중 해당되는 항목에만 내용을 입력해 주세요.<br>
> Jira Ticket 의 경우 EVO-XX 와 해당 티켓에 링크도 걸어주세요<br>
> 만약 위 사항이 없는 간단한 PR 이라면, 해결하려는 문제만 적어주세요.

- 해결하려는 문제: evoui Toast를 사용하는 곳에서 ToastType을 일일이 선언할 필요 없도록 함.

## Changes 🔥

> 이번 PR 에서 변경된 내용을 적어주세요.<br>
> 예시)<br>모달에 사용자에게 더 편리한 기능을 추가합니다. <br>- 모달 자동 스크롤 기능 구현 <br>- 크게 보기 기능 구현<br>…

기존 toast.type의 ToastType namespace를 없애고 ToastType이라는 토스트 종류를 나타내는 타입을 선언하고 내보냄.
