### PR TITLE
Toast: 토스트 initialization 이전에 토스트 한 개를 큐잉할 수 있음.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ node_modules
 .vscode
 
 # build
-dist
+/dist
 docs_dev

--- a/src/evoui/components/Toast/toast.tsx
+++ b/src/evoui/components/Toast/toast.tsx
@@ -340,6 +340,7 @@ function ToastCanvas() {
   useEffect(() => {
     ToastManager.setList = (list: any) => setList(list);
     ToastManager.listChanged = () => setChanged((changed) => !changed);
+    ToastManager.dequeueToast();
 
     return () => {
       ToastManager.setList = null;
@@ -415,13 +416,11 @@ class ToastManager {
   }
 
   static enqueueToast(toastProps: IndependentToastPropsType) {
-    if (!this.isInitialized()) {
-      this.uninitializedError();
-    }
     this.toastQueue.push({ toast: toastProps, key: this.toastKey++ });
     if (
-      this.maxDisplaySize === 0 ||
-      this.toastQueue.length < this.maxDisplaySize
+      this.isInitialized() &&
+      (this.maxDisplaySize === 0 ||
+        this.toastQueue.length < this.maxDisplaySize)
     ) {
       this.dequeueToast();
     }
@@ -441,10 +440,6 @@ class ToastManager {
       this.setList(this.displayList);
       this.listChanged();
     }, toast.toast?.duration ?? 5000);
-  }
-
-  private static uninitializedError() {
-    throw 'Toast did not initialized. Toast component must be mounted somewhere in the React DOM tree.';
   }
 }
 


### PR DESCRIPTION
## Checklist before merge ✅

- [x] PR 제목이 직관적인가요?
  - 짧고 간결하지만 명확하게 (브랜치 명 금지)
  - Jira Ticket 있을 경우 함께 남기기
- [x] 코드 리뷰가 완료되었나요?

## What is this PR? 🚀

> 아래 항목 중 해당되는 항목에만 내용을 입력해 주세요.<br>
> Jira Ticket 의 경우 EVO-XX 와 해당 티켓에 링크도 걸어주세요<br>
> 만약 위 사항이 없는 간단한 PR 이라면, 해결하려는 문제만 적어주세요.

- 해결하려는 문제: initialization 이전에 sendToast가 호출되면 토스트가 initialization 되지 않았다는 오류가 발생한다. initialization 이전에 sendToast가 호출되면 대기열에 큐잉하도록 수정하자. (이번 수정은 한 개만 큐잉 가능, 나중에 여러 개 큐잉 가능하도록 변경 필요)

## Changes 🔥

> 이번 PR 에서 변경된 내용을 적어주세요.<br>
> 예시)<br>모달에 사용자에게 더 편리한 기능을 추가합니다. <br>- 모달 자동 스크롤 기능 구현 <br>- 크게 보기 기능 구현<br>…

토스트 initialization 이전에 enqueue를 시도하면 에러 대신 대기열에 추가를 한다.
initialization 시 대기열의 토스트를 한 번 띄워준다. (나중에 모두 비우도록 변경 필요)
